### PR TITLE
fix vchacha and add mandetory tail flags

### DIFF
--- a/vchacha.s
+++ b/vchacha.s
@@ -122,7 +122,7 @@ round_loop:
 	quarterround v1, v6, v11, v12
 	quarterround v2, v7, v8, v13
 	quarterround v3, v4, v9, v14
-	
+
 	addi t2, t2, -1
 	bnez t2, round_loop
 
@@ -251,8 +251,7 @@ round_loop:
 	vsseg8e32.v v16, (t0)
 	vsseg8e32.v v24, (t1)
 
-	# this might not fit in one vector, but fails when VLMUL is higher?
-	vsetvli a2, a2, e8, m8
+	vsetvli a2, a2, e8, m8, ta, ma
 	vle8.v v0, (a1)
 	vle8.v v8, (t0)
 	vxor.vv v0, v0, v8

--- a/vchacha.s
+++ b/vchacha.s
@@ -21,8 +21,7 @@ instruction_counter:
 	ret
 
 vlmax_u32:
-	li a0, -1
-	vsetvli a0, a0, e32
+	vsetvli a0, x0, e32, m1, ta, ma
 	ret
 
 
@@ -48,7 +47,7 @@ vector_chacha20:
 	srli t3, t0, 6
 encrypt_blocks:
 	# initialize vector state
-	vsetvli t1, t3, e32
+	vsetvli t1, t3, e32, m1, ta, ma
 	# Load 128 bit constant
 	li t0, 0x61707865 # "expa" little endian
 	vmv.v.x v0, t0
@@ -168,7 +167,7 @@ round_loop:
 
 	# load in vector lanes with two strided segment loads
 	# in case this is the final block, reset vl to full blocks
-	vsetvli t5, t4, e32
+	vsetvli t5, t4, e32, m1, ta, ma
 	li t0, 64
 	vlsseg8e32.v v16, (a1), t0
 	add a1, a1, 32
@@ -221,7 +220,7 @@ round_loop:
 
 	# reconstruct vl for all computed blocks
 	add t0, t3, t1
-	vsetvli t0, t0, e32
+	vsetvli t0, t0, e32, m1, ta, ma
 	add t0, t0, -1
 
 	#vse.v v4, (a0)
@@ -246,17 +245,19 @@ round_loop:
 	vslidedown.vx v30, v14, t0
 	vslidedown.vx v31, v15, t0
 	li t0, 1
-	vsetvli zero, t0, e32
-	vsseg8e32.v v16, (sp)
-	addi t0, sp, 32
-	vsseg8e32.v v24, (t0)
+	vsetvli zero, t0, e32, m1, ta, ma
+	addi t0, sp, -64
+	addi t1, sp, -32
+	vsseg8e32.v v16, (t0)
+	vsseg8e32.v v24, (t1)
 
 	# this might not fit in one vector, but fails when VLMUL is higher?
-	vsetvli a2, a2, e8
+	vsetvli a2, a2, e8, m8
 	vle8.v v0, (a1)
-	vle8.v v8, (sp)
+	vle8.v v8, (t0)
 	vxor.vv v0, v0, v8
 	vse8.v v0, (a0)
+
 
 return:
 	ret

--- a/vpoly.s
+++ b/vpoly.s
@@ -215,6 +215,7 @@
 # current accumulated vector state: v1, v2, v3, v4, v5
 vector_poly1305:
 	# save registers
+	addi sp, sp, -96
 	sd s0, 0(sp)
 	sd s1, 8(sp)
 	sd s2, 16(sp)
@@ -494,4 +495,5 @@ return:
 	ld s8, 64(sp)
 	ld s9, 72(sp)
 	ld s11, 80(sp)
+	addi sp, sp, 96
 	ret

--- a/vpoly.s
+++ b/vpoly.s
@@ -262,7 +262,7 @@ continue:
 
 	# a5 is vlmax-1 for e32m1
 	li t0, -1
-	vsetvli a5, t0, e32
+	vsetvli a5, t0, e32, m1, ta, ma
 	addi a5, a5, -1 # vlmax-1
 	# initialize vector to r^1
 	vmv.v.x v6, s0
@@ -351,7 +351,7 @@ precomp:
 	addi a4, a4, 1
 	addi t1, t1, 1
 
-	vsetvli t1, t1, e32
+	vsetvli t1, t1, e32, m1, ta, ma
 	vlseg4e32.v v11, (a0)
 	# increment pointer
 	slli t0, t1, 4
@@ -364,7 +364,7 @@ precomp:
 	vor.vx v24, v24, t0
 
 	li t0, -1
-	vsetvli a5, t0, e32
+	vsetvli a5, t0, e32, m1, ta, ma
 	sub t0, a5, t1
 	slli a5, a5, 4 # block size in bytes
 	vslideup.vx v1, v20, t0

--- a/vpoly.s
+++ b/vpoly.s
@@ -105,7 +105,7 @@
 	vnsrl.wi \a, \d, 0 \mask
 	vand.vx \a, \a, t0 \mask
 	.endm
-	
+
 	vmv.v.i \carry, 0
 	carry_prop\x \a0, \d0
 	carry_prop\x \a1, \d1
@@ -215,18 +215,17 @@
 # current accumulated vector state: v1, v2, v3, v4, v5
 vector_poly1305:
 	# save registers
-	addi sp, sp, -96
-	sd s0, 0(sp)
-	sd s1, 8(sp)
-	sd s2, 16(sp)
-	sd s3, 24(sp)
-	sd s4, 32(sp)
-	sd s5, 40(sp)
-	sd s6, 48(sp)
-	sd s7, 56(sp)
-	sd s8, 64(sp)
-	sd s9, 72(sp)
-	sd s11, 80(sp)
+	sd s0, -8(sp)
+	sd s1, -16(sp)
+	sd s2, -24(sp)
+	sd s3, -32(sp)
+	sd s4, -40(sp)
+	sd s5, -48(sp)
+	sd s6, -56(sp)
+	sd s7, -64(sp)
+	sd s8, -72(sp)
+	sd s9, -80(sp)
+	sd s11, -88(sp)
 
 	# assert input is a multiple of blocksize
 	andi t0, a1, 0xf
@@ -312,7 +311,7 @@ precomp:
 	# end of precomp loop:
 	slli a4, a4, 1 # double exponent
 	blt a4, a5, precomp
-	
+
 	# store post-precomputation instruction counter
 	rdinstret s11
 
@@ -484,16 +483,15 @@ end_vector_loop:
 return:
 	# restore registers
 	mv a0, s11
-	ld s0, 0(sp)
-	ld s1, 8(sp)
-	ld s2, 16(sp)
-	ld s3, 24(sp)
-	ld s4, 32(sp)
-	ld s5, 40(sp)
-	ld s6, 48(sp)
-	ld s7, 56(sp)
-	ld s8, 64(sp)
-	ld s9, 72(sp)
-	ld s11, 80(sp)
-	addi sp, sp, 96
+	ld s0, -8(sp)
+	ld s1, -16(sp)
+	ld s2, -24(sp)
+	ld s3, -32(sp)
+	ld s4, -40(sp)
+	ld s5, -48(sp)
+	ld s6, -56(sp)
+	ld s7, -64(sp)
+	ld s8, -72(sp)
+	ld s9, -80(sp)
+	ld s11, -88(sp)
 	ret


### PR DESCRIPTION
The vchacha implementation crashed when compiled with `-O0`. 
The problem was in the tail handling, specifically how the stack was accessed, it assumed that the stack grows upwards, but it does actually grow downwards (see RISC-V calling convention).

This also adds the tail flags, as they are now mandatory, also, `tu, mu` is the default in gcc, and that will be slower:

>  Prior to v0.9, when these flags were not specified on a vsetvli, they defaulted to mask-undisturbed/tail-undisturbed. The use of vsetvli without these flags is deprecated, however, and specifying a flag setting is now mandatory. The default should perhaps be tail-agnostic/mask-agnostic, so software has to specify when it cares about the non-participating elements, but given the historical meaning of the instruction prior to introduction of these flags, it was decided to always require them in future assembly code. 

It also uses `vsetvli a0, x0, e32, m1, ta, ma` to read VLMAX, as this seems to be the standard way to do it without accessing the CSRs.